### PR TITLE
Added support for RunOnce and RunOncePerDay features

### DIFF
--- a/config-toast-adpwexpiration.xml
+++ b/config-toast-adpwexpiration.xml
@@ -5,6 +5,8 @@
 	<Feature Name="PendingRebootUptime" Enabled="False" />	<!-- Enables the toast for reminding users of restarting their device if it exceeds the uptime defined in MaxUptimeDays -->
 	<Feature Name="PendingRebootCheck" Enabled="False" />	<!-- Enables the toast for reminding users of pending reboots found in registry/WMI. Might not suit ConfigMgr all too well, as if a pending reboot is found, further deployments won't run -->
 	<Feature Name="ADPasswordExpiration" Enabled="True" />	<!-- Enables the toast for reminding users of expiring Active Directory passwords -->
+	<Feature Name="RunOncePerDay" Enabled="False" />	<!-- Ensures that the toast will be displayed no more than one time each day -->
+	<Feature Name="RunOnce" Enabled="False" />	<!-- Ensures that the toast will be displayed no more than one time each day -->
 	<Option Name="TargetOS" Build="19041" />	<!-- The actual build number of the targeted OS. 19041 = 2004 | 18363 = 1909 | 18362 = 1903 | 17763 = 1809. This option has no effect if OSUpgrade is set to False -->
 	<Option Name="MaxUptimeDays" Value="-6" />	<!-- When using the toast for checking for pending reboots. A reboot is considered pending if computer uptime exceeds the value set here -->
 	<Option Name="PendingRebootUptimeText" Enabled="False" />	<!-- Adds an additional group to the toast with text about the uptime of the computer -->

--- a/config-toast-adpwexpiration.xml
+++ b/config-toast-adpwexpiration.xml
@@ -32,6 +32,7 @@
 	<Option Name="Scenario" Type="reminder" />	<!-- Possible values are: reminder | short | long -->
 	<Option Name="Action1" Value="ms-settings:signinoptions:" />	<!-- Action taken when using the Action button. Can be any protocol in Windows -->
 	<Option Name="Action2" Value="https://imab.dk" />	<!-- Action taken when using the Action button. Can be any protocol in Windows -->
+	<Option Name="LastRunRegistryPath" Value="MyNotification" />	<!-- Path where the notification timestamp is stored. Value happened to $($global:RegistryPath) -->
 	<Text Option="GreetGivenName" Enabled="True" />	<!-- Displays the toast with a personal greeting using the users given name retrieved from AD. Will try retrieval from WMI of no local AD -->
 	<Text Option="MultiLanguageSupport" Enabled="False" /> <!-- Enable support for multiple languages. If set to True, the toast notification will look for the users language culture within the config file -->
 	<en-US> <!-- Default fallback language. This language will be used if MultiLanguageSupport is set to False or if no matching language is found -->

--- a/config-toast-officeupgrade.xml
+++ b/config-toast-officeupgrade.xml
@@ -5,6 +5,8 @@
 	<Feature Name="PendingRebootUptime" Enabled="False" />	<!-- Enables the toast for reminding users of restarting their device if it exceeds the uptime defined in MaxUptimeDays -->
 	<Feature Name="PendingRebootCheck" Enabled="False" />	<!-- Enables the toast for reminding users of pending reboots found in registry/WMI. Might not suit ConfigMgr all too well, as if a pending reboot is found, further deployments won't run -->
 	<Feature Name="ADPasswordExpiration" Enabled="False" />	<!-- Enables the toast for reminding users of expiring Active Directory passwords -->
+	<Feature Name="RunOncePerDay" Enabled="False" />	<!-- Ensures that the toast will be displayed no more than one time each day -->
+	<Feature Name="RunOnce" Enabled="False" />	<!-- Ensures that the toast will be displayed no more than one time each day -->
 	<Option Name="TargetOS" Build="19041" />	<!-- The actual build number of the targeted OS. 19041 = 2004 | 18363 = 1909 | 18362 = 1903 | 17763 = 1809. This option has no effect if OSUpgrade is set to False -->
 	<Option Name="MaxUptimeDays" Value="-6" />	<!-- When using the toast for checking for pending reboots. A reboot is considered pending if computer uptime exceeds the value set here -->
 	<Option Name="PendingRebootUptimeText" Enabled="False" />	<!-- Adds an additional group to the toast with text about the uptime of the computer -->

--- a/config-toast-officeupgrade.xml
+++ b/config-toast-officeupgrade.xml
@@ -32,6 +32,7 @@
 	<Option Name="Scenario" Type="reminder" />	<!-- Possible values are: reminder | short | long -->
 	<Option Name="Action1" Value="ToastRunApplicationID:" />	<!-- Action taken when using the Action button. Can be any protocol in Windows -->
 	<Option Name="Action2" Value="https://imab.dk" />	<!-- Action taken when using the Action button. Can be any protocol in Windows -->
+	<Option Name="LastRunRegistryPath" Value="MyNotification" />	<!-- Path where the notification timestamp is stored. Value happened to $($global:RegistryPath) -->
 	<Text Option="GreetGivenName" Enabled="True" />	<!-- Displays the toast with a personal greeting using the users given name retrieved from AD. Will try retrieval from WMI of no local AD -->
 	<Text Option="MultiLanguageSupport" Enabled="False" /> <!-- Enable support for multiple languages. If set to True, the toast notification will look for the users language culture within the config file -->
 	<en-US> <!-- Default fallback language. This language will be used if MultiLanguageSupport is set to False or if no matching language is found -->

--- a/config-toast-osupgrade.xml
+++ b/config-toast-osupgrade.xml
@@ -5,6 +5,8 @@
 	<Feature Name="PendingRebootUptime" Enabled="False" />	<!-- Enables the toast for reminding users of restarting their device if it exceeds the uptime defined in MaxUptimeDays -->
 	<Feature Name="PendingRebootCheck" Enabled="False" />	<!-- Enables the toast for reminding users of pending reboots found in registry/WMI. Might not suit ConfigMgr all too well, as if a pending reboot is found, further deployments won't run -->
 	<Feature Name="ADPasswordExpiration" Enabled="False" />	<!-- Enables the toast for reminding users of expiring Active Directory passwords -->
+	<Feature Name="RunOncePerDay" Enabled="False" />	<!-- Ensures that the toast will be displayed no more than one time each day -->
+	<Feature Name="RunOnce" Enabled="False" />	<!-- Ensures that the toast will be displayed no more than one time each day -->
 	<Option Name="TargetOS" Build="19043" />	<!-- The actual build number of the targeted OS. 19041 = 2004 | 18363 = 1909 | 18362 = 1903 | 17763 = 1809. This option has no effect if OSUpgrade is set to False -->
 	<Option Name="MaxUptimeDays" Value="-6" />	<!-- When using the toast for checking for pending reboots. A reboot is considered pending if computer uptime exceeds the value set here -->
 	<Option Name="PendingRebootUptimeText" Enabled="False" />	<!-- Adds an additional group to the toast with text about the uptime of the computer -->

--- a/config-toast-osupgrade.xml
+++ b/config-toast-osupgrade.xml
@@ -32,6 +32,7 @@
 	<Option Name="Scenario" Type="reminder" />	<!-- Possible values are: reminder | short | long -->
 	<Option Name="Action1" Value="ToastRunPackageID:" />	<!-- Action taken when using the Action button. Can be any protocol in Windows -->
 	<Option Name="Action2" Value="https://imab.dk" />	<!-- Action taken when using the Action button. Can be any protocol in Windows -->
+	<Option Name="LastRunRegistryPath" Value="MyNotification" />	<!-- Path where the notification timestamp is stored. Value happened to $($global:RegistryPath) -->
 	<Text Option="GreetGivenName" Enabled="True" />	<!-- Displays the toast with a personal greeting using the users given name retrieved from AD. Will try retrieval from WMI of no local AD -->
 	<Text Option="MultiLanguageSupport" Enabled="False" /> <!-- Enable support for multiple languages. If set to True, the toast notification will look for the users language culture within the config file -->
 	<en-US> <!-- Default fallback language. This language will be used if MultiLanguageSupport is set to False or if no matching language is found -->

--- a/config-toast-rebootpending.xml
+++ b/config-toast-rebootpending.xml
@@ -32,6 +32,7 @@
 	<Option Name="Scenario" Type="reminder" />	<!-- Possible values are: reminder | short | long -->
 	<Option Name="Action1" Value="ToastReboot:" />	<!-- Action taken when using the Action button. Can be any protocol in Windows -->
 	<Option Name="Action2" Value="https://imab.dk" />	<!-- Action taken when using the Action button. Can be any protocol in Windows -->
+	<Option Name="LastRunRegistryPath" Value="MyNotification" />	<!-- Path where the notification timestamp is stored. Value happened to $($global:RegistryPath) -->
 	<Text Option="GreetGivenName" Enabled="True" />	<!-- Displays the toast with a personal greeting using the users given name retrieved from AD. Will try retrieval from WMI of no local AD -->
 	<Text Option="MultiLanguageSupport" Enabled="False" /> <!-- Enable support for multiple languages. If set to True, the toast notification will look for the users language culture within the config file -->
 	<en-US> <!-- Default fallback language. This language will be used if MultiLanguageSupport is set to False or if no matching language is found -->

--- a/config-toast-rebootpending.xml
+++ b/config-toast-rebootpending.xml
@@ -5,6 +5,8 @@
 	<Feature Name="PendingRebootUptime" Enabled="True" />	<!-- Enables the toast for reminding users of restarting their device if it exceeds the uptime defined in MaxUptimeDays -->
 	<Feature Name="PendingRebootCheck" Enabled="False" />	<!-- Enables the toast for reminding users of pending reboots found in registry/WMI. Might not suit ConfigMgr all too well, as if a pending reboot is found, further deployments won't run -->
 	<Feature Name="ADPasswordExpiration" Enabled="False" />	<!-- Enables the toast for reminding users of expiring Active Directory passwords -->
+	<Feature Name="RunOncePerDay" Enabled="False" />	<!-- Ensures that the toast will be displayed no more than one time each day -->
+	<Feature Name="RunOnce" Enabled="False" />	<!-- Ensures that the toast will be displayed no more than one time each day -->
 	<Option Name="TargetOS" Build="19041" />	<!-- The actual build number of the targeted OS. 19041 = 2004 | 18363 = 1909 | 18362 = 1903 | 17763 = 1809. This option has no effect if OSUpgrade is set to False -->
 	<Option Name="MaxUptimeDays" Value="-6" />	<!-- When using the toast for checking for pending reboots. A reboot is considered pending if computer uptime exceeds the value set here -->
 	<Option Name="PendingRebootUptimeText" Enabled="True" />	<!-- Adds an additional group to the toast with text about the uptime of the computer -->

--- a/config-toast-waasfu.xml
+++ b/config-toast-waasfu.xml
@@ -32,6 +32,7 @@
 	<Option Name="Scenario" Type="reminder" />	<!-- Possible values are: reminder | short | long -->
 	<Option Name="Action1" Value="ToastRunUpdateID:" />	<!-- Action taken when using the Action button. Can be any protocol in Windows -->
 	<Option Name="Action2" Value="https://imab.dk" />	<!-- Action taken when using the Action button. Can be any protocol in Windows -->
+	<Option Name="LastRunRegistryPath" Value="MyNotification" />	<!-- Path where the notification timestamp is stored. Value happened to $($global:RegistryPath) -->
 	<Text Option="GreetGivenName" Enabled="True" />	<!-- Displays the toast with a personal greeting using the users given name retrieved from AD. Will try retrieval from WMI of no local AD -->
 	<Text Option="MultiLanguageSupport" Enabled="False" /> <!-- Enable support for multiple languages. If set to True, the toast notification will look for the users language culture within the config file -->
 	<en-US> <!-- Default fallback language. This language will be used if MultiLanguageSupport is set to False or if no matching language is found -->

--- a/config-toast-waasfu.xml
+++ b/config-toast-waasfu.xml
@@ -5,6 +5,8 @@
 	<Feature Name="PendingRebootUptime" Enabled="False" />	<!-- Enables the toast for reminding users of restarting their device if it exceeds the uptime defined in MaxUptimeDays -->
 	<Feature Name="PendingRebootCheck" Enabled="False" />	<!-- Enables the toast for reminding users of pending reboots found in registry/WMI. Might not suit ConfigMgr all too well, as if a pending reboot is found, further deployments won't run -->
 	<Feature Name="ADPasswordExpiration" Enabled="False" />	<!-- Enables the toast for reminding users of expiring Active Directory passwords -->
+	<Feature Name="RunOncePerDay" Enabled="False" />	<!-- Ensures that the toast will be displayed no more than one time each day -->
+	<Feature Name="RunOnce" Enabled="False" />	<!-- Ensures that the toast will be displayed no more than one time each day -->
 	<Option Name="TargetOS" Build="19042" />	<!-- The actual build number of the targeted OS. 19041 = 2004 | 18363 = 1909 | 18362 = 1903 | 17763 = 1809. This option has no effect if OSUpgrade is set to False -->
 	<Option Name="MaxUptimeDays" Value="-6" />	<!-- When using the toast for checking for pending reboots. A reboot is considered pending if computer uptime exceeds the value set here -->
 	<Option Name="PendingRebootUptimeText" Enabled="False" />	<!-- Adds an additional group to the toast with text about the uptime of the computer -->

--- a/config-toast.xml
+++ b/config-toast.xml
@@ -5,6 +5,8 @@
 	<Feature Name="PendingRebootUptime" Enabled="True" />	<!-- Enables the toast for reminding users of restarting their device if it exceeds the uptime defined in MaxUptimeDays -->
 	<Feature Name="PendingRebootCheck" Enabled="False" />	<!-- Enables the toast for reminding users of pending reboots found in registry/WMI. Might not suit ConfigMgr all too well, as if a pending reboot is found, further deployments won't run -->
 	<Feature Name="ADPasswordExpiration" Enabled="False" />	<!-- Enables the toast for reminding users of expiring Active Directory passwords -->
+	<Feature Name="RunOncePerDay" Enabled="False" />	<!-- Ensures that the toast will be displayed no more than one time each day -->
+	<Feature Name="RunOnce" Enabled="False" />	<!-- Ensures that the toast will be displayed no more than one time each day -->
 	<Option Name="TargetOS" Build="19041" />	<!-- The actual build number of the targeted OS. 19041 = 2004 | 18363 = 1909 | 18362 = 1903 | 17763 = 1809. This option has no effect if OSUpgrade is set to False -->
 	<Option Name="MaxUptimeDays" Value="-6" />	<!-- When using the toast for checking for pending reboots. A reboot is considered pending if computer uptime exceeds the value set here -->
 	<Option Name="PendingRebootUptimeText" Enabled="True" />	<!-- Adds an additional group to the toast with text about the uptime of the computer -->

--- a/config-toast.xml
+++ b/config-toast.xml
@@ -32,6 +32,7 @@
 	<Option Name="Scenario" Type="alarm" />	<!-- Possible values are: reminder | short | long -->
 	<Option Name="Action1" Value="ToastReboot:" />	<!-- Action taken when using the Action button. Can be any protocol in Windows -->
 	<Option Name="Action2" Value="https://imab.dk" />	<!-- Action taken when using the Action button. Can be any protocol in Windows -->
+	<Option Name="LastRunRegistryPath" Value="MyNotification" />	<!-- Path where the notification timestamp is stored. Value happened to $($global:RegistryPath) -->
 	<Text Option="GreetGivenName" Enabled="True" />	<!-- Displays the toast with a personal greeting using the users given name retrieved from AD. Will try retrieval from WMI of no local AD -->
 	<Text Option="MultiLanguageSupport" Enabled="False" /> <!-- Enable support for multiple languages. If set to True, the toast notification will look for the users language culture within the config file -->
 	<en-US> <!-- Default fallback language. This language will be used if MultiLanguageSupport is set to False or if no matching language is found -->


### PR DESCRIPTION
Added support to limit the notification appearance to only one time per day or just one time. Data is stored in registry under the HKCU hive per user and per notification.

For example, a scheduled task is triggered on logon and on session unlock so you can catch people that power their computer on each day and those using sleep but you don't flood them as the notification can be limited to appear only once per day.

## Config XML Changes
Two new features (Might be changed to options maybe?): 

- RunOnce: if enabled, the notification will be displayed only one time even if it is triggered again. It's still possible to clear the registry to allow a new display. If enabled, RunOncePerDay value will be ignored.
- RunOncePerDay: if enabled, the notification will be displayed only one time per day even if it is triggered multiple time. It's still possible to clear the registry to allow a new display.

One new option:

- LastRunRegistryPath; defines the path in registry where the timestamp of the last execution should be stored. It should be different for each notification so they don't share the same information. The path will be appended to the `$($global:RegistryPath)` variable.

## New functions

- Get-DaysSinceLastRun: returns the number of days since the notification last ran. Returns $null if it has never run before.
- Save-NotifificationTimeStamp: saves the timestamp of the last notification execution in registry. The value is save to the path set with the `LastRunRegistryPath` option.