### PR TITLE
Custom Protocol Support For Notification itself

### DIFF
--- a/New-ToastNotification-AppLocker-Edition.ps1
+++ b/New-ToastNotification-AppLocker-Edition.ps1
@@ -1708,6 +1708,7 @@ if(-NOT[string]::IsNullOrEmpty($Xml)) {
         $Scenario = $Xml.Configuration.Option | Where-Object {$_.Name -like 'Scenario'} | Select-Object -ExpandProperty 'Type'
         $Action1 = $Xml.Configuration.Option | Where-Object {$_.Name -like 'Action1'} | Select-Object -ExpandProperty 'Value'
         $Action2 = $Xml.Configuration.Option | Where-Object {$_.Name -like 'Action2'} | Select-Object -ExpandProperty 'Value'
+        $LaunchProtocol = $Xml.Configuration.Option | Where-Object {$_.Name -like 'LaunchProtocol'} | Select-Object -ExpandProperty 'Value'
         $GreetGivenName = $Xml.Configuration.Text | Where-Object {$_.Option -like 'GreetGivenName'} | Select-Object -ExpandProperty 'Enabled'
         $MultiLanguageSupport = $Xml.Configuration.Text | Where-Object {$_.Option -like 'MultiLanguageSupport'} | Select-Object -ExpandProperty 'Enabled'
         # Load Toast Notification buttons
@@ -2268,7 +2269,7 @@ if ($GreetGivenName -eq "True") {
 if (($ActionButton1Enabled -eq "True") -AND ($DismissButtonEnabled -eq "True")) {
     Write-Log -Message "Creating the xml for action button and dismiss button"
 [xml]$Toast = @"
-<toast scenario="$Scenario">
+<toast scenario="$Scenario" activationType= "protocol" launch="$LaunchProtocol">
     <visual>
     <binding template="ToastGeneric">
         <image placement="hero" src="$HeroImage"/>
@@ -2304,7 +2305,7 @@ if (($ActionButton1Enabled -eq "True") -AND ($DismissButtonEnabled -eq "True")) 
 if (($ActionButton1Enabled -ne "True") -AND ($DismissButtonEnabled -ne "True")) {
     Write-Log -Message "Creating the xml for no action button and no dismiss button"
 [xml]$Toast = @"
-<toast scenario="$Scenario">
+<toast scenario="$Scenario" activationType= "protocol" launch="$LaunchProtocol">
     <visual>
     <binding template="ToastGeneric">
         <image placement="hero" src="$HeroImage"/>
@@ -2338,7 +2339,7 @@ if (($ActionButton1Enabled -ne "True") -AND ($DismissButtonEnabled -ne "True")) 
 if (($ActionButton1Enabled -eq "True") -AND ($DismissButtonEnabled -ne "True")) {
     Write-Log -Message "Creating the xml for no dismiss button"
 [xml]$Toast = @"
-<toast scenario="$Scenario">
+<toast scenario="$Scenario" activationType= "protocol" launch="$LaunchProtocol">
     <visual>
     <binding template="ToastGeneric">
         <image placement="hero" src="$HeroImage"/>
@@ -2373,7 +2374,7 @@ if (($ActionButton1Enabled -eq "True") -AND ($DismissButtonEnabled -ne "True")) 
 if (($ActionButton1Enabled -ne "True") -AND ($DismissButtonEnabled -eq "True")) {
     Write-Log -Message "Creating the xml for no action button"
 [xml]$Toast = @"
-<toast scenario="$Scenario">
+<toast scenario="$Scenario" activationType= "protocol" launch="$LaunchProtocol">
     <visual>
     <binding template="ToastGeneric">
         <image placement="hero" src="$HeroImage"/>
@@ -2410,7 +2411,7 @@ if ($ActionButton2Enabled -eq "True") {
     Write-Log -Message "This will always enable both action buttons and the dismiss button" -Level Warn
     Write-Log -Message "Replacing any previous formatting of the toast xml" -Level Warn
 [xml]$Toast = @"
-<toast scenario="$Scenario">
+<toast scenario="$Scenario" activationType= "protocol" launch="$LaunchProtocol">
     <visual>
     <binding template="ToastGeneric">
         <image placement="hero" src="$HeroImage"/>
@@ -2449,7 +2450,7 @@ if ($SnoozeButtonEnabled -eq "True") {
     Write-Log -Message "This will always enable the action button as well as the dismiss button" -Level Warn
     Write-Log -Message "Replacing any previous formatting of the toast xml" -Level Warn
 [xml]$Toast = @"
-<toast scenario="$Scenario">
+<toast scenario="$Scenario" activationType= "protocol" launch="$LaunchProtocol">
     <visual>
     <binding template="ToastGeneric">
         <image placement="hero" src="$HeroImage"/>

--- a/New-ToastNotification.ps1
+++ b/New-ToastNotification.ps1
@@ -1688,6 +1688,7 @@ if(-NOT[string]::IsNullOrEmpty($Xml)) {
         $Scenario = $Xml.Configuration.Option | Where-Object {$_.Name -like 'Scenario'} | Select-Object -ExpandProperty 'Type'
         $Action1 = $Xml.Configuration.Option | Where-Object {$_.Name -like 'Action1'} | Select-Object -ExpandProperty 'Value'
         $Action2 = $Xml.Configuration.Option | Where-Object {$_.Name -like 'Action2'} | Select-Object -ExpandProperty 'Value'
+        $LaunchProtocol = $Xml.Configuration.Option | Where-Object {$_.Name -like 'LaunchProtocol'} | Select-Object -ExpandProperty 'Value'
         $GreetGivenName = $Xml.Configuration.Text | Where-Object {$_.Option -like 'GreetGivenName'} | Select-Object -ExpandProperty 'Enabled'
         $MultiLanguageSupport = $Xml.Configuration.Text | Where-Object {$_.Option -like 'MultiLanguageSupport'} | Select-Object -ExpandProperty 'Enabled'
         # Load Toast Notification buttons
@@ -2211,7 +2212,7 @@ if ($GreetGivenName -eq "True") {
 if (($ActionButton1Enabled -eq "True") -AND ($DismissButtonEnabled -eq "True")) {
     Write-Log -Message "Creating the xml for action button and dismiss button"
 [xml]$Toast = @"
-<toast scenario="$Scenario">
+<toast scenario="$Scenario" activationType= "protocol" launch="$LaunchProtocol">
     <visual>
     <binding template="ToastGeneric">
         <image placement="hero" src="$HeroImage"/>
@@ -2247,7 +2248,7 @@ if (($ActionButton1Enabled -eq "True") -AND ($DismissButtonEnabled -eq "True")) 
 if (($ActionButton1Enabled -ne "True") -AND ($DismissButtonEnabled -ne "True")) {
     Write-Log -Message "Creating the xml for no action button and no dismiss button"
 [xml]$Toast = @"
-<toast scenario="$Scenario">
+<toast scenario="$Scenario" activationType= "protocol" launch="$LaunchProtocol">
     <visual>
     <binding template="ToastGeneric">
         <image placement="hero" src="$HeroImage"/>
@@ -2281,7 +2282,7 @@ if (($ActionButton1Enabled -ne "True") -AND ($DismissButtonEnabled -ne "True")) 
 if (($ActionButton1Enabled -eq "True") -AND ($DismissButtonEnabled -ne "True")) {
     Write-Log -Message "Creating the xml for no dismiss button"
 [xml]$Toast = @"
-<toast scenario="$Scenario">
+<toast scenario="$Scenario" activationType= "protocol" launch="$LaunchProtocol">
     <visual>
     <binding template="ToastGeneric">
         <image placement="hero" src="$HeroImage"/>
@@ -2316,7 +2317,7 @@ if (($ActionButton1Enabled -eq "True") -AND ($DismissButtonEnabled -ne "True")) 
 if (($ActionButton1Enabled -ne "True") -AND ($DismissButtonEnabled -eq "True")) {
     Write-Log -Message "Creating the xml for no action button"
 [xml]$Toast = @"
-<toast scenario="$Scenario">
+<toast scenario="$Scenario" activationType= "protocol" launch="$LaunchProtocol">
     <visual>
     <binding template="ToastGeneric">
         <image placement="hero" src="$HeroImage"/>
@@ -2353,7 +2354,7 @@ if ($ActionButton2Enabled -eq "True") {
     Write-Log -Message "This will always enable both action buttons and the dismiss button" -Level Warn
     Write-Log -Message "Replacing any previous formatting of the toast xml" -Level Warn
 [xml]$Toast = @"
-<toast scenario="$Scenario">
+<toast scenario="$Scenario" activationType= "protocol" launch="$LaunchProtocol">
     <visual>
     <binding template="ToastGeneric">
         <image placement="hero" src="$HeroImage"/>
@@ -2392,7 +2393,7 @@ if ($SnoozeButtonEnabled -eq "True") {
     Write-Log -Message "This will always enable the action button as well as the dismiss button" -Level Warn
     Write-Log -Message "Replacing any previous formatting of the toast xml" -Level Warn
 [xml]$Toast = @"
-<toast scenario="$Scenario">
+<toast scenario="$Scenario" activationType= "protocol" launch="$LaunchProtocol">
     <visual>
     <binding template="ToastGeneric">
         <image placement="hero" src="$HeroImage"/>

--- a/config-toast-adpwexpiration.xml
+++ b/config-toast-adpwexpiration.xml
@@ -27,6 +27,7 @@
 	<Option Name="HeroImageName" Value="ToastHeroImageDefault.jpg" /> <!-- File name of the image shown in the top of the toast notification -->	
 	<Option Name="ActionButton1" Enabled="True" />	<!-- Enables or disables the action button. -->
 	<Option Name="ActionButton2" Enabled="True" />	<!-- Enables or disables the action button. -->
+	<Option Name="LaunchProtocol" Value="microsoft-edge:" /> <!-- Action taken when the notification is clicked. Can be any protocol in Windows -->
 	<Option Name="DismissButton" Enabled="True" />	<!-- Enables or disables the dismiss button. -->
 	<Option Name="SnoozeButton" Enabled="False" /> <!-- Enabling this option will always enable action button and dismiss button -->
 	<Option Name="Scenario" Type="reminder" />	<!-- Possible values are: reminder | short | long -->

--- a/config-toast-officeupgrade.xml
+++ b/config-toast-officeupgrade.xml
@@ -32,6 +32,7 @@
 	<Option Name="Scenario" Type="reminder" />	<!-- Possible values are: reminder | short | long -->
 	<Option Name="Action1" Value="ToastRunApplicationID:" />	<!-- Action taken when using the Action button. Can be any protocol in Windows -->
 	<Option Name="Action2" Value="https://imab.dk" />	<!-- Action taken when using the Action button. Can be any protocol in Windows -->
+	<Option Name="LaunchProtocol" Value="microsoft-edge:" /> <!-- Action taken when the notification is clicked. Can be any protocol in Windows -->
 	<Text Option="GreetGivenName" Enabled="True" />	<!-- Displays the toast with a personal greeting using the users given name retrieved from AD. Will try retrieval from WMI of no local AD -->
 	<Text Option="MultiLanguageSupport" Enabled="False" /> <!-- Enable support for multiple languages. If set to True, the toast notification will look for the users language culture within the config file -->
 	<en-US> <!-- Default fallback language. This language will be used if MultiLanguageSupport is set to False or if no matching language is found -->

--- a/config-toast-osupgrade.xml
+++ b/config-toast-osupgrade.xml
@@ -27,6 +27,7 @@
 	<Option Name="HeroImageName" Value="ToastHeroImageWindows.jpg" /> <!-- File name of the image shown in the top of the toast notification -->	
 	<Option Name="ActionButton1" Enabled="True" />	<!-- Enables or disables the action button. -->
 	<Option Name="ActionButton2" Enabled="True" />	<!-- Enables or disables the action button. -->
+	<Option Name="LaunchProtocol" Value="microsoft-edge:" /> <!-- Action taken when the notification is clicked. Can be any protocol in Windows -->
 	<Option Name="DismissButton" Enabled="True" />	<!-- Enables or disables the dismiss button. -->
 	<Option Name="SnoozeButton" Enabled="False" /> <!-- Enabling this option will always enable action button and dismiss button -->
 	<Option Name="Scenario" Type="reminder" />	<!-- Possible values are: reminder | short | long -->

--- a/config-toast-rebootpending.xml
+++ b/config-toast-rebootpending.xml
@@ -32,6 +32,7 @@
 	<Option Name="Scenario" Type="reminder" />	<!-- Possible values are: reminder | short | long -->
 	<Option Name="Action1" Value="ToastReboot:" />	<!-- Action taken when using the Action button. Can be any protocol in Windows -->
 	<Option Name="Action2" Value="https://imab.dk" />	<!-- Action taken when using the Action button. Can be any protocol in Windows -->
+	<Option Name="LaunchProtocol" Value="microsoft-edge:" /> <!-- Action taken when the notification is clicked. Can be any protocol in Windows -->
 	<Text Option="GreetGivenName" Enabled="True" />	<!-- Displays the toast with a personal greeting using the users given name retrieved from AD. Will try retrieval from WMI of no local AD -->
 	<Text Option="MultiLanguageSupport" Enabled="False" /> <!-- Enable support for multiple languages. If set to True, the toast notification will look for the users language culture within the config file -->
 	<en-US> <!-- Default fallback language. This language will be used if MultiLanguageSupport is set to False or if no matching language is found -->

--- a/config-toast-waasfu.xml
+++ b/config-toast-waasfu.xml
@@ -32,6 +32,7 @@
 	<Option Name="Scenario" Type="reminder" />	<!-- Possible values are: reminder | short | long -->
 	<Option Name="Action1" Value="ToastRunUpdateID:" />	<!-- Action taken when using the Action button. Can be any protocol in Windows -->
 	<Option Name="Action2" Value="https://imab.dk" />	<!-- Action taken when using the Action button. Can be any protocol in Windows -->
+	<Option Name="LaunchProtocol" Value="microsoft-edge:" /> <!-- Action taken when the notification is clicked. Can be any protocol in Windows -->
 	<Text Option="GreetGivenName" Enabled="True" />	<!-- Displays the toast with a personal greeting using the users given name retrieved from AD. Will try retrieval from WMI of no local AD -->
 	<Text Option="MultiLanguageSupport" Enabled="False" /> <!-- Enable support for multiple languages. If set to True, the toast notification will look for the users language culture within the config file -->
 	<en-US> <!-- Default fallback language. This language will be used if MultiLanguageSupport is set to False or if no matching language is found -->

--- a/config-toast.xml
+++ b/config-toast.xml
@@ -32,6 +32,7 @@
 	<Option Name="Scenario" Type="reminder" />	<!-- Possible values are: reminder | short | long | alarm -->
 	<Option Name="Action1" Value="ToastReboot:" />	<!-- Action taken when using the Action button. Can be any protocol in Windows -->
 	<Option Name="Action2" Value="https://imab.dk" />	<!-- Action taken when using the Action button. Can be any protocol in Windows -->
+	<Option Name="LaunchProtocol" Value="microsoft-edge:" /> <!-- Action taken when the notification is clicked. Can be any protocol in Windows -->
 	<Text Option="GreetGivenName" Enabled="True" />	<!-- Displays the toast with a personal greeting using the users given name retrieved from AD. Will try retrieval from WMI of no local AD -->
 	<Text Option="MultiLanguageSupport" Enabled="False" /> <!-- Enable support for multiple languages. If set to True, the toast notification will look for the users language culture within the config file -->
 	<en-US> <!-- Default fallback language. This language will be used if MultiLanguageSupport is set to False or if no matching language is found -->


### PR DESCRIPTION
This allows for a custom protocol to be called when the Notification itself is called. For example could be used to get around Toast Notifications ability to be dismissed. If the user clicks the notification you could trigger the notification to be displayed again. Also useful to perform the same action as one of the protocols assigned to the action buttons. Currently sets the default protocol to open Microsoft edge to demonstrate the feature in all the example config files. If no custom protocol is set I have not seen any negative effects.