### PR TITLE
Update RunToastHidden.cmd

### DIFF
--- a/RunToastHidden.cmd
+++ b/RunToastHidden.cmd
@@ -1,2 +1,8 @@
 REM This file is intended to be used when the toast notification script is used with scheduled tasks with the Hidden.vbs file. See the documentation for further details
-powershell.exe -file "C:\ProgramData\ToastNotificationScript\PendingReboot\New-ToastNotification.ps1" -Config "\\YourNetworkPath\ToastNotificationScript\Configs\config-toast-pendingreboot.xml"
+
+IF "%PROCESSOR_ARCHITEW6432%" == "AMD64" (
+SET pspath="C:\Windows\SysNative\WindowsPowerShell\v1.0\powershell.exe"
+) ELSE (
+SET pspath="C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe"
+)
+%pspath% -file "C:\ProgramData\ToastNotificationScript\PendingReboot\New-ToastNotification.ps1" -Config "\\YourNetworkPath\ToastNotificationScript\Configs\config-toast-pendingreboot.xml"


### PR DESCRIPTION
If you are running the script on 64bit OS from 32bit context, like a SCCM program, the script will not see the 64bit registries.
Fix to open PowerShell in 64bit context, when running from 32bit context like SCCM programs.